### PR TITLE
Define anomaVerify in terms of anomaVerifyWithMessage

### DIFF
--- a/Anoma/Data/Maybe.juvix
+++ b/Anoma/Data/Maybe.juvix
@@ -1,0 +1,8 @@
+-- | Functions that should be moved to Stdlib.Data.Maybe
+module Anoma.Data.Maybe;
+
+import Stdlib.Prelude open;
+
+isJust {A} : Maybe A -> Bool
+  | (just _) := true
+  | nothing := false;

--- a/Anoma/System.juvix
+++ b/Anoma/System.juvix
@@ -1,6 +1,7 @@
 --- Functions that are or will be provided by the Anoma system.
 module Anoma.System;
 
+import Anoma.Data.Maybe open;
 import Stdlib.Prelude open;
 
 syntax alias PublicKey := Nat;
@@ -61,14 +62,15 @@ axiom anomaSignDetached : {Message : Type}
   -> Signature;
 
 --- Verifies a signed message against a public key.
-builtin anoma-verify
-axiom anomaVerify :
-  -- | The signed message to verify.
-  SignedMessage
-  -- | The signer public key to verify against.
-  -> PublicKey
-  -- | The verification result.
-  -> Bool;
+---
+--- Arguments:
+---   signedMessage : The signed message to verify.
+---   publicKey : The signer public key to verify against.
+---
+--- Returns:
+---   ;true; if the signedMessage was verified.
+anomaVerify (signedMessage : SignedMessage) (publicKey : PublicKey) : Bool :=
+  anomaVerifyWithMessage signedMessage publicKey |> isJust {Unit};
 
 --- Verifies a signature against a message and public key.
 builtin anoma-verify-detached


### PR DESCRIPTION
This change is made to avoid adding an additional builtin function to the Juvix compiler as it can be simply implemented in terms of `anomaVerifyWithMessage`.

The polymorphism of `anomaVerifyWithMessage` requires us to apply a type. Any type will do here because the value is not used. I've chosen `Unit` because then it's clear to readers of the source code that the result of `anomaVerifyWithMessage` is being discarded.

This commit also adds `isJust` which should be added to the Juvix standard library along with other utilities for the Maybe type.