### PR TITLE
Update to be compatible with the latest Juvix stdlib

### DIFF
--- a/Anoma/Extra.juvix
+++ b/Anoma/Extra.juvix
@@ -27,13 +27,13 @@ partitionResources (tx : Transaction) : ResourcePartition :=
 
 --- Obtain the ;Resource; associated with a commitment
 commitmentResource (commitment : Nat) : Resource :=
-  snd (anomaDecode {Nat × Resource} commitment);
+  snd (anomaDecode {Pair Nat Resource} commitment);
 
 --- Obtain the ;Resource; associated with a nullifier
 nullifierResource (nullifier : Nat) : Resource :=
   let
-    n1 : Nat × Nat := anomaDecode nullifier;
-    n2 : String × Resource := anomaDecode (fst n1);
+    n1 : Pair Nat Nat := anomaDecode nullifier;
+    n2 : Pair String Resource := anomaDecode (fst n1);
   in snd n2;
 
 --- The kind of a ;Resource;.
@@ -50,7 +50,7 @@ nullifierHeader : String := "annullo";
 --- https://github.com/anoma/anoma/blob/d6a61451ae8fd0f046c083f5ca4a4f38e7ecffb1/lib/anoma/resource.ex#L66
 nullifier (r : Resource) (secretKey : Nat) : Nat :=
   let
-    n : String × Resource := nullifierHeader, r;
+    n : Pair String Resource := nullifierHeader, r;
   in anomaEncode
     (anomaEncode n, anomaSignDetached n secretKey);
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Juvix Anoma Standard Library
+
+A Juvix library for writing Anoma applications.
+
+## Minimum Supported Juvix Version
+
+To use this library you need to use a [Juvix nightly build](https://github.com/anoma/juvix-nightly-builds/releases/latest) from 2024-06-28 or later.

--- a/examples/Kudos/IntentDsl.juvix
+++ b/examples/Kudos/IntentDsl.juvix
@@ -25,7 +25,7 @@ type Intention :=
 
 type Clause :=
   mkClause {
-    lhs : Intention × QuantifiedAssets;
+    lhs : Pair Intention QuantifiedAssets;
     rhs : QuantifiedAssets
   };
 
@@ -48,17 +48,17 @@ exactly (a : Asset) : QuantifiedAssets :=
   };
 
 want
-  (a : QuantifiedAssets) : Intention × QuantifiedAssets :=
+  (a : QuantifiedAssets) : Pair Intention QuantifiedAssets :=
   Want, a;
 
 give
-  (a : QuantifiedAssets) : Intention × QuantifiedAssets :=
+  (a : QuantifiedAssets) : Pair Intention QuantifiedAssets :=
   Give, a;
 
 syntax operator for pair;
 
 for
-  (l : Intention × QuantifiedAssets)
+  (l : Pair Intention QuantifiedAssets)
   (qs : QuantifiedAssets)
   : Clause :=
   mkClause@{


### PR DESCRIPTION
This PR makes makes the library compatible with the latest Juvix standard library. In particular:

* `A × B` is now `Pair A B`

A README is also added which describes the minimum juvix nightly version that's compatible with the library. 