### PR TITLE
Improve type safety of common Anoma types

### DIFF
--- a/Anoma.juvix
+++ b/Anoma.juvix
@@ -2,4 +2,5 @@ module Anoma;
 
 import Anoma.Extra open public;
 import Anoma.System open public;
+import Anoma.Transaction open public;
 import Anoma.Types open public;

--- a/Anoma/Extra.juvix
+++ b/Anoma/Extra.juvix
@@ -2,6 +2,7 @@
 module Anoma.Extra;
 
 import Anoma.Types open;
+import Anoma.Transaction open;
 import Stdlib.Prelude open;
 import Anoma.System open;
 
@@ -22,11 +23,12 @@ partitionResources (tx : Transaction) : ResourcePartition :=
   };
 
 --- Obtain the ;Resource; associated with a commitment
-commitmentResource (commitment : Nat) : Resource :=
-  snd (anomaDecode {Pair Nat Resource} commitment);
+commitmentResource : Commitment -> Resource
+  | (Commitment.mk commitment) := snd (anomaDecode {Pair Nat Resource} commitment);
 
 --- Obtain the ;Resource; associated with a nullifier
-nullifierResource (nullifier : Nat) : Resource :=
+nullifierResource : Nullifier -> Resource
+  | (Nullifier.mk nullifier) :=
   let
     n1 : Pair Nat Nat := anomaDecode nullifier;
     n2 : Pair String Resource := anomaDecode (fst n1);
@@ -35,7 +37,8 @@ nullifierResource (nullifier : Nat) : Resource :=
 --- The kind of a ;Resource;.
 --- This is some combination of `anomaEncode (Resource.logic r)` and
 --- `anomaEncode (Resource.label r)` defined by Anoma.
-anomaKind (r : Resource) : Nat := anomaEncode (Resource.logic r, Resource.label r);
+anomaKind (r : Resource) : Kind :=
+  anomaEncode (Resource.logic r, Resource.label r) |> Kind.mk;
 
 --- The header to use in a nullifier cell
 --- https://github.com/anoma/anoma/blob/ea25f88cea52226d77c8392ae16bbfc5a7ffccee/lib/anoma/resource.ex#L36
@@ -43,14 +46,16 @@ nullifierHeader : String := "annullo";
 
 --- The nullifier of the given resource.
 --- https://github.com/anoma/anoma/blob/d6a61451ae8fd0f046c083f5ca4a4f38e7ecffb1/lib/anoma/resource.ex#L66
-nullifier (r : Resource) (secretKey : Nat) : Nat :=
+nullifier (r : Resource) (privateKey : PrivateKey) : Nullifier :=
   let
     n : Pair String Resource := nullifierHeader, r;
-  in anomaEncode (anomaEncode n, anomaSignDetached n secretKey);
+  in anomaEncode
+    (anomaEncode n, anomaSignDetached n privateKey) |> Nullifier.mk;
 
 -- The header to use in a commitment cell
 commitmentHeader : String := "committo";
 
 --- A commitment to the given resource
 --- https://github.com/anoma/anoma/blob/ea25f88cea52226d77c8392ae16bbfc5a7ffccee/lib/anoma/resource.ex#L55
-commitment (r : Resource) : Nat := anomaEncode (commitmentHeader, r);
+commitment (r : Resource) : Commitment :=
+  anomaEncode (commitmentHeader, r) |> Commitment.mk;

--- a/Anoma/Extra.juvix
+++ b/Anoma/Extra.juvix
@@ -29,16 +29,15 @@ commitmentResource : Commitment -> Resource
 --- Obtain the ;Resource; associated with a nullifier
 nullifierResource : Nullifier -> Resource
   | (Nullifier.mk nullifier) :=
-  let
-    n1 : Pair Nat Nat := anomaDecode nullifier;
-    n2 : Pair String Resource := anomaDecode (fst n1);
-  in snd n2;
+    let
+      n1 : Pair Nat Nat := anomaDecode nullifier;
+      n2 : Pair String Resource := anomaDecode (fst n1);
+    in snd n2;
 
 --- The kind of a ;Resource;.
 --- This is some combination of `anomaEncode (Resource.logic r)` and
 --- `anomaEncode (Resource.label r)` defined by Anoma.
-anomaKind (r : Resource) : Kind :=
-  anomaEncode (Resource.logic r, Resource.label r) |> Kind.mk;
+anomaKind (r : Resource) : Kind := anomaEncode (Resource.logic r, Resource.label r) |> Kind.mk;
 
 --- The header to use in a nullifier cell
 --- https://github.com/anoma/anoma/blob/ea25f88cea52226d77c8392ae16bbfc5a7ffccee/lib/anoma/resource.ex#L36
@@ -49,13 +48,11 @@ nullifierHeader : String := "annullo";
 nullifier (r : Resource) (privateKey : PrivateKey) : Nullifier :=
   let
     n : Pair String Resource := nullifierHeader, r;
-  in anomaEncode
-    (anomaEncode n, anomaSignDetached n privateKey) |> Nullifier.mk;
+  in anomaEncode (anomaEncode n, anomaSignDetached n privateKey) |> Nullifier.mk;
 
 -- The header to use in a commitment cell
 commitmentHeader : String := "committo";
 
 --- A commitment to the given resource
 --- https://github.com/anoma/anoma/blob/ea25f88cea52226d77c8392ae16bbfc5a7ffccee/lib/anoma/resource.ex#L55
-commitment (r : Resource) : Commitment :=
-  anomaEncode (commitmentHeader, r) |> Commitment.mk;
+commitment (r : Resource) : Commitment := anomaEncode (commitmentHeader, r) |> Commitment.mk;

--- a/Anoma/System.juvix
+++ b/Anoma/System.juvix
@@ -10,24 +10,26 @@ open Builtin using {anomaGet; anomaEncode; anomaDecode} public;
 
 --- Signs a message with a private key and returns a signed message.
 {-# inline: true #-}
-anomaSign : {Message : Type}
-  -- | The message to sign.
-  -> Message
-  -- | The signing private key.
-  -> PrivateKey
-  -- | The resulting signed message.
-  -> SignedMessage
+anomaSign
+  : {Message : Type}
+    -- | The message to sign.
+    -> Message
+    -- | The signing private key.
+    -> PrivateKey
+    -- | The resulting signed message.
+    -> SignedMessage
   | message (PrivateKey.mk privKey) := Builtin.anomaSign message privKey |> SignedMessage.mk;
 
 --- Signs a message with a private key and returns the signature.
 {-# inline: true #-}
-anomaSignDetached : {Message : Type}
-  -- | The message to sign.
-  -> Message
-  -- | The signing private key.
-  -> PrivateKey
-  -- The resulting signature
-  -> Signature
+anomaSignDetached
+  : {Message : Type}
+    -- | The message to sign.
+    -> Message
+    -- | The signing private key.
+    -> PrivateKey
+    -- The resulting signature
+    -> Signature
   | message (PrivateKey.mk privKey) := Builtin.anomaSignDetached message privKey |> Signature.mk;
 
 --- Verifies a signed message against a public key.
@@ -37,31 +39,35 @@ anomaSignDetached : {Message : Type}
 --- publicKey : The signer public key to verify against.
 ---
 --- Returns:
----   ;true; if the signedMessage was verified.
+--- ;true; if the signedMessage was verified.
 {-# inline: true #-}
 anomaVerify (signedMessage : SignedMessage) (publicKey : PublicKey) : Bool :=
   anomaVerifyWithMessage signedMessage publicKey |> isJust {Unit};
 
 --- Verifies a signature against a message and public key.
 {-# inline: true #-}
-anomaVerifyDetached : {Message : Type}
-  -- | The signature to verify.
-  -> Signature
-  -- | The message to verify against.
-  -> Message
-  -- | The signer public key to verify against.
-  -> PublicKey
-  -- | The verification result.
-  -> Bool
-  | (Signature.mk signature) message (PublicKey.mk pubKey) := Builtin.anomaVerifyDetached signature message pubKey;
+anomaVerifyDetached
+  : {Message : Type}
+    -- | The signature to verify.
+    -> Signature
+    -- | The message to verify against.
+    -> Message
+    -- | The signer public key to verify against.
+    -> PublicKey
+    -- | The verification result.
+    -> Bool
+  | (Signature.mk signature) message (PublicKey.mk pubKey) :=
+    Builtin.anomaVerifyDetached signature message pubKey;
 
 --- Verifies a signature against a message and public key and return the message on success.
 {-# inline: true #-}
-anomaVerifyWithMessage : {Message : Type}
-  -- | The signed message to verify.
-  -> SignedMessage
-  -- | The signer public key to verify against.
-  -> PublicKey
-  -- | The original message.
-  -> Maybe Message
-  | (SignedMessage.mk signedMessage) (PublicKey.mk pubKey) := Builtin.anomaVerifyWithMessage signedMessage pubKey;
+anomaVerifyWithMessage
+  : {Message : Type}
+    -- | The signed message to verify.
+    -> SignedMessage
+    -- | The signer public key to verify against.
+    -> PublicKey
+    -- | The original message.
+    -> Maybe Message
+  | (SignedMessage.mk signedMessage) (PublicKey.mk pubKey) :=
+    Builtin.anomaVerifyWithMessage signedMessage pubKey;

--- a/Anoma/System/Builtin.juvix
+++ b/Anoma/System/Builtin.juvix
@@ -1,50 +1,72 @@
---- Functions that are or will be provided by the Anoma system.
-module Anoma.System;
+module Anoma.System.Builtin;
 
 import Anoma.Data.Maybe open;
 import Stdlib.Prelude open;
-import Anoma.Types open;
-import Anoma.System.Builtin as Builtin;
 
-open Builtin using {anomaGet; anomaEncode; anomaDecode} public;
+syntax alias PublicKey := Nat;
+syntax alias PrivateKey := Nat;
+
+syntax alias Signature := Nat;
+syntax alias SignedMessage := Nat;
+
+--- Retrieves a value by key from Anoma's key-value store.
+builtin anoma-get
+axiom anomaGet : {Value Key : Type}
+  -- | The key.
+  -> Key
+  -- | The value.
+  -> Value;
+
+--- Encodes a value into a natural number.
+builtin anoma-encode
+axiom anomaEncode : {Value : Type}
+  -- | The value to encode.
+  -> Value
+  -- | The encoded natural number.
+  -> Nat;
+
+--- Decodes a value from a natural number.
+builtin anoma-decode
+axiom anomaDecode : {Value : Type}
+  -- | The natural number to decode .
+  -> Nat
+  -- | The decoded value.
+  -> Value;
 
 --- Signs a message with a private key and returns a signed message.
-{-# inline: true #-}
-anomaSign : {Message : Type}
+builtin anoma-sign
+axiom anomaSign : {Message : Type}
   -- | The message to sign.
   -> Message
   -- | The signing private key.
   -> PrivateKey
   -- | The resulting signed message.
-  -> SignedMessage
-  | message (PrivateKey.mk privKey) := Builtin.anomaSign message privKey |> SignedMessage.mk;
+  -> SignedMessage;
 
 --- Signs a message with a private key and returns the signature.
-{-# inline: true #-}
-anomaSignDetached : {Message : Type}
+builtin anoma-sign-detached
+axiom anomaSignDetached : {Message : Type}
   -- | The message to sign.
   -> Message
   -- | The signing private key.
   -> PrivateKey
   -- The resulting signature
-  -> Signature
-  | message (PrivateKey.mk privKey) := Builtin.anomaSignDetached message privKey |> Signature.mk;
+  -> Signature;
 
 --- Verifies a signed message against a public key.
 ---
 --- Arguments:
---- signedMessage : The signed message to verify.
---- publicKey : The signer public key to verify against.
+---   signedMessage : The signed message to verify.
+---   publicKey : The signer public key to verify against.
 ---
 --- Returns:
 ---   ;true; if the signedMessage was verified.
-{-# inline: true #-}
 anomaVerify (signedMessage : SignedMessage) (publicKey : PublicKey) : Bool :=
   anomaVerifyWithMessage signedMessage publicKey |> isJust {Unit};
 
 --- Verifies a signature against a message and public key.
-{-# inline: true #-}
-anomaVerifyDetached : {Message : Type}
+builtin anoma-verify-detached
+axiom anomaVerifyDetached : {Message : Type}
   -- | The signature to verify.
   -> Signature
   -- | The message to verify against.
@@ -52,16 +74,14 @@ anomaVerifyDetached : {Message : Type}
   -- | The signer public key to verify against.
   -> PublicKey
   -- | The verification result.
-  -> Bool
-  | (Signature.mk signature) message (PublicKey.mk pubKey) := Builtin.anomaVerifyDetached signature message pubKey;
+  -> Bool;
 
 --- Verifies a signature against a message and public key and return the message on success.
-{-# inline: true #-}
-anomaVerifyWithMessage : {Message : Type}
+builtin anoma-verify-with-message
+axiom anomaVerifyWithMessage : {Message : Type}
   -- | The signed message to verify.
   -> SignedMessage
   -- | The signer public key to verify against.
   -> PublicKey
   -- | The original message.
-  -> Maybe Message
-  | (SignedMessage.mk signedMessage) (PublicKey.mk pubKey) := Builtin.anomaVerifyWithMessage signedMessage pubKey;
+  -> Maybe Message;

--- a/Anoma/System/Builtin.juvix
+++ b/Anoma/System/Builtin.juvix
@@ -53,17 +53,6 @@ axiom anomaSignDetached : {Message : Type}
   -- The resulting signature
   -> Signature;
 
---- Verifies a signed message against a public key.
----
---- Arguments:
----   signedMessage : The signed message to verify.
----   publicKey : The signer public key to verify against.
----
---- Returns:
----   ;true; if the signedMessage was verified.
-anomaVerify (signedMessage : SignedMessage) (publicKey : PublicKey) : Bool :=
-  anomaVerifyWithMessage signedMessage publicKey |> isJust {Unit};
-
 --- Verifies a signature against a message and public key.
 builtin anoma-verify-detached
 axiom anomaVerifyDetached : {Message : Type}

--- a/Anoma/Transaction.juvix
+++ b/Anoma/Transaction.juvix
@@ -30,6 +30,7 @@ Delta : Type := List DeltaComponent;
 -- defined in the same module.
 module Helper;
   syntax alias Proof := Resource;
+
   ComplianceProof : Type := Pair Nat Nat;
 
   positive

--- a/Anoma/Transaction.juvix
+++ b/Anoma/Transaction.juvix
@@ -1,47 +1,20 @@
 module Anoma.Transaction;
 
 import Stdlib.Prelude open;
-
-module Kind;
-  module Private;
-    type Kind := mk {id : Nat};
-
-    instance
-    Kind-Eq : Eq Kind :=
-      mkEq@{
-        eq (d1 d2 : Kind) : Bool := Kind.id d1 == Kind.id d2
-      };
-
-    instance
-    Kind-Ord : Ord Kind :=
-      mkOrd@{
-        cmp (d1 d2 : Kind) : Ordering := Ord.cmp (Kind.id d1) (Kind.id d2)
-      };
-
-  end;
-
-  open Private using {Kind} public;
-
-  syntax alias Eq := Private.Kind-Eq;
-
-end;
-
-open Kind using {Kind} public;
-
-open Kind.Private;
+import Anoma.Types open;
 
 module DeltaComponent;
 
   type DeltaComponent :=
     mk {
-      denom : Nat;
+      denom : Kind;
       sign : Bool;
       amount : Nat
     };
 
   zero : DeltaComponent :=
     mk@{
-      denom := 0;
+      denom := Kind.mk 0;
       sign := true;
       amount := 0
     };
@@ -57,22 +30,18 @@ Delta : Type := List DeltaComponent;
 -- defined in the same module.
 module Helper;
   syntax alias Proof := Resource;
-  syntax alias Commitment := Nat;
-  syntax alias Nullifier := Nat;
-
   ComplianceProof : Type := Pair Nat Nat;
 
   positive
   type Resource :=
     mkResource {
       logic : Resource -> Transaction -> Bool;
-      -- TODO: Should be String
       label : Nat;
       quantity : Nat;
       data : Nat;
       eph : Bool;
       nonce : Nat;
-      npk : Nat;
+      npk : PublicKey;
       rseed : Nat
     };
 

--- a/Anoma/Types.juvix
+++ b/Anoma/Types.juvix
@@ -1,3 +1,166 @@
+--- Common types used in the library
 module Anoma.Types;
 
-import Anoma.Transaction open public;
+import Stdlib.Prelude open;
+
+import Stdlib.Trait.Ord.Eq open using {fromOrdToEq};
+
+module Nullifier;
+
+  type Nullifier := mk {unNullifier : Nat};
+
+  open Nullifier public;
+end;
+
+open Nullifier using {Nullifier} public;
+
+module Commitment;
+
+  type Commitment := mk {unCommitment : Nat};
+
+  open Commitment public;
+end;
+
+open Commitment using {Commitment} public;
+
+module Kind;
+
+  type Kind := mk {unKind : Nat};
+
+  open Kind public;
+end;
+
+open Kind using {Kind} public;
+
+module PublicKey;
+
+  type PublicKey := mk {unPublicKey : Nat};
+
+  open PublicKey public;
+end;
+
+open PublicKey using {PublicKey} public;
+
+module PrivateKey;
+
+  type PrivateKey := mk {unPrivateKey : Nat};
+
+  open PrivateKey public;
+end;
+
+open PrivateKey using {PrivateKey} public;
+
+module Signature;
+
+  type Signature := mk {unSignature : Nat};
+
+  open Signature public;
+end;
+
+open Signature using {Signature} public;
+
+module SignedMessage;
+
+  type SignedMessage := mk {unSignedMessage : Nat};
+
+  open SignedMessage public;
+end;
+
+open SignedMessage using {SignedMessage} public;
+
+module KeyPair;
+
+  --- A cryptographic keypair
+  type KeyPair :=
+    mk {
+      pubKey : PublicKey;
+      privKey : PrivateKey
+    };
+
+  open KeyPair public;
+
+end;
+
+open KeyPair using {KeyPair} public;
+
+instance
+NullifierOrd : Ord Nullifier :=
+  mkOrd@{
+    cmp : Nullifier -> Nullifier -> Ordering
+      | (Nullifier.mk x1) (Nullifier.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+NullifierEq : Eq Nullifier := fromOrdToEq;
+
+instance
+CommitmentOrd : Ord Commitment :=
+  mkOrd@{
+    cmp : Commitment -> Commitment -> Ordering
+      | (Commitment.mk x1) (Commitment.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+CommitmentEq : Eq Commitment := fromOrdToEq;
+
+instance
+KindOrd : Ord Kind :=
+  mkOrd@{
+    cmp : Kind -> Kind -> Ordering
+      | (Kind.mk x1) (Kind.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+KindEq : Eq Kind := fromOrdToEq;
+
+instance
+PublicKeyOrd : Ord PublicKey :=
+  mkOrd@{
+    cmp : PublicKey -> PublicKey -> Ordering
+      | (PublicKey.mk x1) (PublicKey.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+PublicKeyEq : Eq PublicKey := fromOrdToEq;
+
+instance
+PrivateKeyOrd : Ord PrivateKey :=
+  mkOrd@{
+    cmp : PrivateKey -> PrivateKey -> Ordering
+      | (PrivateKey.mk x1) (PrivateKey.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+PrivateKeyEq : Eq PrivateKey := fromOrdToEq;
+
+instance
+SignatureOrd : Ord Signature :=
+  mkOrd@{
+    cmp : Signature -> Signature -> Ordering
+      | (Signature.mk x1) (Signature.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+SignatureEq : Eq Signature := fromOrdToEq;
+
+instance
+SignedMessageOrd : Ord SignedMessage :=
+  mkOrd@{
+    cmp : SignedMessage -> SignedMessage -> Ordering
+      | (SignedMessage.mk x1) (SignedMessage.mk x2) := Ord.cmp x1 x2
+  };
+
+instance
+SignedMessageEq : Eq SignedMessage := fromOrdToEq;
+
+instance
+KeyPairOrd : Ord KeyPair :=
+  let
+    toProd : KeyPair -> _
+      | (KeyPair.mk x1 x2) := x1, x2;
+  in mkOrd@{
+    cmp (x1 x2 : KeyPair) : Ordering := Ord.cmp (toProd x1) (toProd x2)
+  };
+
+instance
+KeyPairEq : Eq KeyPair := fromOrdToEq;

--- a/test/AlwaysValid/Transaction.juvix
+++ b/test/AlwaysValid/Transaction.juvix
@@ -8,7 +8,8 @@ open Transaction;
 open DeltaComponent;
 
 privKey : PrivateKey :=
-  PrivateKey.mk 0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac11662fc6e7829efcb0f4500827d49bb699af7b5475cef5220fd600ebbf9709a58;
+  PrivateKey.mk
+    0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac11662fc6e7829efcb0f4500827d49bb699af7b5475cef5220fd600ebbf9709a58;
 
 pubKey : PublicKey :=
   PublicKey.mk 0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac1;

--- a/test/AlwaysValid/Transaction.juvix
+++ b/test/AlwaysValid/Transaction.juvix
@@ -2,15 +2,16 @@ module AlwaysValid.Transaction;
 
 import Anoma.Transaction open;
 import Stdlib.Prelude open;
-import Anoma.Extra open;
+import Anoma open;
 
 open Transaction;
 open DeltaComponent;
 
-privKey : Nat :=
-  0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac11662fc6e7829efcb0f4500827d49bb699af7b5475cef5220fd600ebbf9709a58;
+privKey : PrivateKey :=
+  PrivateKey.mk 0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac11662fc6e7829efcb0f4500827d49bb699af7b5475cef5220fd600ebbf9709a58;
 
-pubKey : Nat := 0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac1;
+pubKey : PublicKey :=
+  PublicKey.mk 0xddd315c76991f8e058760cacdd19c21bf6a12c72bc229a60ad6aaa314fa07ac1;
 
 alwaysTrueLogic (r : Resource) (tx : Transaction) : Bool := true;
 

--- a/test/Resource/Tests.juvix
+++ b/test/Resource/Tests.juvix
@@ -12,7 +12,7 @@ testResource : Resource :=
     data := 0;
     eph := true;
     nonce := 0;
-    npk := 0;
+    npk := PublicKey.mk 0;
     rseed := 0
   };
 


### PR DESCRIPTION
Previously we used Nat for almost all types (PublicKey, Commitment, Nullifier etc.) because the Anoma builtin functions and the Anoma Node interface requries it.

However, the Juvix Anoma backend represents Juvix records as Nockma tuples. In particular records with a single field (i.e newtypes) are represented by their wrapped value. Therefore using a newtype instead of the wrapped type does not change the runtime representation in Nockma so we can freely use them in this library.

### Anoma Builtin Function Signatures

If we used the newtypes in the Anoma builtin function signatures then we would have to make the newtypes builtin too in order that they could be supported in the JuvixCore evaluator. This is undesirable because we would have to update the compiler's Anoma backend whenever we changed these newtypes.

Instead we define wrapper functions in `Anoma.System` which delegate to the builtins in `Anoma.System.Builtin`. The functions in `Anoma.System.Builtin` are not exposed in the main `Anoma` module. The wrapper functions are inlined to avoid adding a function call at runtime.