### PR TITLE
Add support for Anoma Node key-value backend

### DIFF
--- a/Anoma.juvix
+++ b/Anoma.juvix
@@ -4,3 +4,4 @@ import Anoma.Extra open public;
 import Anoma.System open public;
 import Anoma.Transaction open public;
 import Anoma.Types open public;
+import Anoma.KeyValue as KeyValue public;

--- a/Anoma/KeyValue.juvix
+++ b/Anoma/KeyValue.juvix
@@ -1,0 +1,16 @@
+--- This module contains types for use with the Anoma Node key-value backend
+module Anoma.KeyValue;
+
+import Stdlib.Prelude open;
+
+--- A ;Key; represents a key in Anoma storage.
+type Key := mkKey {path : List String};
+
+--- An ;Assignment; represents an assignment of a key to a value in Anoma Node
+--- Storage. This should be used as the type of `main` when compiling a Juvix
+--- module for submission to the Anoma Node key-value backend.
+type Assignment A :=
+  assign {
+    key : Key;
+    value : A
+  };

--- a/examples/KeyValue.juvix
+++ b/examples/KeyValue.juvix
@@ -1,0 +1,17 @@
+--- An example of a Juvix module that can be used with the Anoma Node key-value
+--- backend.
+module KeyValue;
+
+import Stdlib.Prelude open;
+import Anoma.System open using {anomaGet};
+import Anoma.KeyValue open;
+
+--- A function that increments the value at a specific key in Anoma Node
+--- Storage.
+main : Assignment Nat :=
+  let
+    key :=
+      mkKey@{
+        path := ["August"; "Water"; "Miki"]
+      };
+  in assign key (anomaGet key + 1);


### PR DESCRIPTION
The example provided is intended to be used with the Anoma Node key-value backend. In particular it will not work with the Anoma Node resource machine.

The key will not work until key normalisation is implemented in Anoma Node:

* https://github.com/anoma/anoma/issues/661

An example of this example working in the Anoma Node test suite (with hacked key normalisation):

* https://github.com/anoma/anoma/pull/714